### PR TITLE
Refactor `AperturePlot` into `ApertureFigure` and extract multichannel support

### DIFF
--- a/src/libertem_ui/windows/com.py
+++ b/src/libertem_ui/windows/com.py
@@ -54,7 +54,8 @@ class CoMImagingWindow(VirtualDetectorWindow, ui_type=WindowType.STANDALONE):
         super().initialize(dataset, with_layout=False)
 
         self._current_params = CoMParamsUI()
-        self.nav_plot._channel_map = {
+        self.nav_plot._channel_map = 'DICT'
+        self.nav_plot._channel_data = {
             CoMChanN.SHIFT_MAGNITUDE: 'magnitude',
             CoMChanN.RAW_X_SHIFT: ('raw_shifts', lambda buffer: buffer[..., 1]),
             CoMChanN.RAW_Y_SHIFT: ('raw_shifts', lambda buffer: buffer[..., 0]),


### PR DESCRIPTION
Supports https://github.com/matbryan52/image-viewer by refactoring the image display components out of the LiberTEM `LivePlot2D` interface. Similarly extracts the multichannel image support, previously only supported `UDFResults` as dict but now can select multi channel data from `np.ndarray.ndim == 3, dict[str, np.ndarray], Sequence[np.ndarray]`.