### PR TITLE
Implement manual outlier clipping, fix downsampled image updates

### DIFF
--- a/src/libertem_ui/display/image_datashader.py
+++ b/src/libertem_ui/display/image_datashader.py
@@ -321,7 +321,10 @@ class DatashadeHelper:
     def axis_overlaps(obj_range, view_range):
         return (obj_range[0] <= view_range[1]) and (view_range[0] <= obj_range[1])
 
-    def update_view(self, event: RangesUpdate, force: bool = False, do_update: bool = True):
+    def update_view(
+        self, event: RangesUpdate, force: bool = False,
+        do_update: bool = True, with_clims: bool = False
+    ):
         """
         This is the main callback linked to the RangesUpdate event
 
@@ -433,6 +436,7 @@ class DatashadeHelper:
         new_data = {
             **new_cds_coords,
             **BokehImageCons._get_array(shaded),
+            'clim_update': [with_clims],
         }
         if do_update:
             self.im.raw_update(**new_data)

--- a/src/libertem_ui/display/image_db.py
+++ b/src/libertem_ui/display/image_db.py
@@ -843,8 +843,20 @@ if (freeze.active.length == 1){
 }
 
 const data = cds.data.image[0]
-const mean = data.reduce((acc, v) => acc + v, 0) / data.length
-const std = Math.sqrt(data.reduce((acc, v) => acc + (Math.abs(v - mean) ** 2), 0) / data.length)
+var non_nan = Math.max(data.length, 1)
+const mean = data.reduce((acc, v) => {
+    if (!Number.isNaN(v)) {
+        return acc + v
+    }
+    non_nan -= 1
+    return acc
+}, 0) / Math.max(non_nan, 1)
+var std = Math.sqrt(data.reduce((acc, v) => {
+    return Number.isNaN(v) ? acc : acc + (Math.abs(v - mean) ** 2)}
+, 0) / Math.max(non_nan, 1))
+if (std == 0.) {
+    std = 0.1
+}
 
 const data_low = cds.data.val_low[0]
 const data_high = cds.data.val_high[0]

--- a/src/libertem_ui/display/image_db.py
+++ b/src/libertem_ui/display/image_db.py
@@ -97,6 +97,7 @@ class BokehImageCons:
             **cls._get_minmax(minmax),
             'cbar_slider': [False],
             'cbar_centered': [False],
+            'clim_update': [True],  # when False this will disable clim updates in the jscallback
         }
 
     @staticmethod
@@ -253,6 +254,7 @@ class BokehImage(DisplayBase):
                     self._px_offset,
                 ),
             }
+        data['clim_update'] = [True]
         super().update(
             **data,
             **self.constructor._get_minmax(minmax),
@@ -571,6 +573,12 @@ if (low <= 0.  && high <= 0.) {
     @staticmethod
     def _clim_slider_update_image_js():
         return '''
+
+const clim_update = cb_obj.data.clim_update[0]
+if (!clim_update){
+    return
+}
+
 if (freeze.active.length == 1){
     return
 }

--- a/src/libertem_ui/live_plot.py
+++ b/src/libertem_ui/live_plot.py
@@ -219,16 +219,20 @@ class ApertureFigure:
         )
 
         self._floatpanel = pn.layout.FloatPanel(
-            close_btn,
-            self.im.color.get_cmap_select(),
+            pn.Row(
+                self.im.color.get_cmap_select(width=200),
+                pn.layout.HSpacer(width=50),
+                close_btn,
+            ),
+            self.im.color.get_cmap_invert(),
             self.im.color.get_cmap_slider(),
+            self.im.color._gamma_slider,
             self.im.color._cbar_freeze,
             pn.Row(
                 self.im.color._full_scale_btn,
                 self.im.color.clip_outliers_btn,
+                self.im.color.clip_outliers_sigma_spinner,
             ),
-            self.im.color._gamma_slider,
-            self.im.color.get_cmap_invert(),
             name=name,
             config={
                 "headerControls": {

--- a/src/libertem_ui/live_plot.py
+++ b/src/libertem_ui/live_plot.py
@@ -223,7 +223,10 @@ class ApertureFigure:
             self.im.color.get_cmap_select(),
             self.im.color.get_cmap_slider(),
             self.im.color._cbar_freeze,
-            self.im.color._full_scale_btn,
+            pn.Row(
+                self.im.color._full_scale_btn,
+                self.im.color.clip_outliers_btn,
+            ),
             self.im.color._gamma_slider,
             self.im.color.get_cmap_invert(),
             name=name,


### PR DESCRIPTION
Adds features requested by @sk1p  in https://github.com/matbryan52/image-viewer/issues/5

There are certainly still some sharp edges, notably if you click `Autorange` while zoomed in, the standard deviation of the image is computed on the zoomed in version because this is currently done in the browser itself rather than on the Python side. Similarly the JS code which does the calculation is not great, and will fail for a zero-length array or an array with NaN values in it.

Also modifies the behaviour of the downsampled image such that zooming / panning doesn't cause the color limits to change.