### PR TITLE
Add multi-dimension ravel for `channel_dimension`

### DIFF
--- a/src/libertem_ui/live_plot.py
+++ b/src/libertem_ui/live_plot.py
@@ -153,16 +153,9 @@ class ApertureFigure:
         if isinstance(data, np.ndarray):
             if data.ndim == 2:
                 return data
-            elif data.ndim == 3:
-                self._channel_data = data
-                assert isinstance(dim, int), "3D data requires int channel dim"
-                self._channel_map = (dim % data.ndim,)
-                slices = tuple(
-                    slice(None) if i not in self._channel_map else 0
-                    for i in range(self._channel_data.ndim)
-                )
-                out_data = self._channel_data[slices]
-            elif data.ndim > 3:
+            elif data.ndim > 2:
+                if isinstance(dim, int):
+                    dim = (dim,)
                 try:
                     if not all(isinstance(i, int) for i in dim):
                         raise TypeError
@@ -172,7 +165,7 @@ class ApertureFigure:
                     num_nav = len(dim)
                 except TypeError:
                     raise TypeError(
-                        'Must supply sequence of int channel dims when data.ndim > 3'
+                        'Must supply sequence of int channel dims when data.ndim > 2'
                     )
                 if (data.ndim - num_nav) != 2 or (num_nav != len(set(dim))):
                     raise ValueError(


### PR DESCRIPTION
Add feature requested by @sk1p https://github.com/matbryan52/image-viewer/issues/3

The parameter `channel_dimension` can now accept `tuple[int, ...]` for `data.ndim > 3`. The dimensions are internally normalised (`i % data.ndim`) and sorted, then must be unique after this pre-processing, and combine to slice 2D arrays from the whole datacube. Frames are sliced out in C-order, of course!

Looks like this in practice:

![image](https://github.com/LiberTEM/LiberTEM-panel-ui/assets/78845903/12374a32-97ca-4786-b493-fa4dc608e85b)
