### PR TITLE
Fix `getter` of `select_roi` for multi-channel case

### DIFF
--- a/src/libertem_ui/applications/image_utils.py
+++ b/src/libertem_ui/applications/image_utils.py
@@ -30,7 +30,7 @@ def select_roi(
     rectangles = fig._mask_elements[0]
 
     def getter() -> list[tuple[slice, slice]]:
-        return fig.get_mask_rect_as_slices(image.shape)
+        return fig.get_mask_rect_as_slices(fig.im.array.shape)
 
     return fig, rectangles, getter
 


### PR DESCRIPTION
The shape in `get_mask_rect_as_slices(shape)` must be 2D. Calling `getter` would result in this exception:

    ---------------------------------------------------------------------------
    ValueError                                Traceback (most recent call last)
    Cell In[29], line 1
    ----> 1 getter()

    File /LiberTEM-panel-ui/src/libertem_ui/applications/image_utils.py:33, in select_roi.<locals>.getter()
	 32 def getter() -> list[tuple[slice, slice]]:
    ---> 33     return fig.get_mask_rect_as_slices(image.shape)

    File /LiberTEM-panel-ui/src/libertem_ui/live_plot.py:454, in ApertureFigure.get_mask_rect_as_slices(self, shape)
	452     if not isinstance(element, Rectangles):
	453         continue
    --> 454     slices.extend(element.as_slices(shape))
	455 return slices

    File /LiberTEM-panel-ui/src/libertem_ui/display/display_base.py:1105, in Rectangles.as_slices(self, shape)
       1103 slices = []
       1104 for _, row in self.cds.to_df().iterrows():
    -> 1105     slices.append(rectangle_to_slice(
       1106         cx=row[self.rectangles.x],
       1107         cy=row[self.rectangles.y],
       1108         w=abs(row[self.rectangles.width]),
       1109         h=abs(row[self.rectangles.height]),
       1110         shape=shape
       1111     ))
       1112 return slices

    File /LiberTEM-panel-ui/src/libertem_ui/display/display_base.py:1118, in rectangle_to_slice(cx, cy, w, h, shape)
       1116 lefttop = cx - w / 2, cy - h / 2
       1117 rightbottom = cx + w / 2, cy + h / 2
    -> 1118 lefttop, _ = clip_posxy_array(lefttop, shape, round=True, to_int=True)
       1119 rightbottom, _ = clip_posxy_array(rightbottom, shape, round=True, to_int=True)
       1120 slice_y = slice(lefttop[1], rightbottom[1] + 1)

    File /LiberTEM-panel-ui/src/libertem_ui/utils/__init__.py:75, in clip_posxy_array(pos_xy, shape, round, to_int)
	 73 def clip_posxy_array(pos_xy, shape, round=True, to_int=True):
	 74     pos_xy = np.asarray(pos_xy).reshape(-1, 2)
    ---> 75     h, w = shape
	 76     clipped_x, ib_x = sanitize_val(pos_xy[:, 0], clip_to=w - 1, round=round, to_int=to_int)
	 77     clipped_y, ib_y = sanitize_val(pos_xy[:, 1], clip_to=h - 1, round=round, to_int=to_int)

    ValueError: too many values to unpack (expected 2)