### PR TITLE
Add missing "from __future__ import annotations"

### DIFF
--- a/src/libertem_ui/live_plot.py
+++ b/src/libertem_ui/live_plot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from typing import TYPE_CHECKING, Callable
 


### PR DESCRIPTION
Fixes

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/alex/source/modules/LiberTEM-panel-ui/src/libertem_ui/live_plot.py", line 18, in <module>
    class AperturePlot(Live2DPlot, ApertureFigure):
  File "/home/alex/source/modules/LiberTEM-panel-ui/src/libertem_ui/live_plot.py", line 91, in AperturePlot
    udf_results: UDFResultDict,
                 ^^^^^^^^^^^^^
NameError: name 'UDFResultDict' is not defined
```