### PR TITLE
Add table of transform values + fix missing cursor tool

### DIFF
--- a/src/libertem_ui/applications/image_utils.py
+++ b/src/libertem_ui/applications/image_utils.py
@@ -351,6 +351,21 @@ export default async function (args, obj, data, context) {
                                              end=10.,
                                              width=125)
 
+    def _transform_md():
+        transform = transformer_moving.get_combined_transform()
+        scale_x, scale_y = transform.scale
+        trans_x, trans_y = transform.translation
+        return f"""### Transform:
+
+| Rotation | Scale   | Shear    | Translation   |
+| -------- | ------- | -------- | -------       |
+| {np.rad2deg(transform.rotation):.1f}  | ({scale_x:.3f}, {scale_y:.3f}) | {transform.shear:.2f}  | ({trans_x:.1f}, {trans_y:.1f}) |
+"""  # noqa
+
+    transform_md = pn.pane.Markdown(
+        object=_transform_md(),
+    )
+
     def update_moving(*updates, fix_clims=True):
         moving = transformer_moving.get_transformed_image()
         if show_diff_cbox.value:
@@ -359,6 +374,7 @@ export default async function (args, obj, data, context) {
             to_display = moving
         moving_im.update(to_display)
         fig.push()
+        transform_md.object = _transform_md()
 
     # def update_moving():
         # update_moving_sync()
@@ -475,7 +491,10 @@ export default async function (args, obj, data, context) {
 
     return pn.Column(
         pn.Row(
-            fig.layout,
+            pn.Column(
+                fig.layout,
+                transform_md,
+            ),
             pn.Column(
                 undo_button,
                 translate_step_input,

--- a/src/libertem_ui/applications/image_utils.py
+++ b/src/libertem_ui/applications/image_utils.py
@@ -409,6 +409,7 @@ export default async function (args, obj, data, context) {
         .new()
         .from_pos(*tuple(a // 2 for a in static.shape))
         .on(fig.fig)
+        .editable(selected=True)
     )
     origin_cursor.cursor.line_color = 'cyan'
     origin_cursor.cursor.line_alpha = 0.


### PR DESCRIPTION
As mentioned today @sk1p, feel free to adapt the formatting of the displayed values.

I also fixed the missing tool for the `Cursor`, this lets you set the center of rotation manually by dragging the cursor, after de-selecting `'Center-origin'`.