### PR TITLE
Add a setter function

### DIFF
--- a/src/libertem_ui/applications/image_utils.py
+++ b/src/libertem_ui/applications/image_utils.py
@@ -490,6 +490,11 @@ export default async function (args, obj, data, context) {
     def getter() -> AffineTransform:
         return transformer_moving.get_combined_transform()
 
+    def setter(transf):
+        transformer_moving.clear_transforms()
+        transformer_moving.add_transform(transf)
+        update_moving()
+
     fig._toolbar.insert(0, show_diff_cbox)
     fig._toolbar.insert(0, wobble_step_input)
     fig._toolbar.insert(0, wobble_alpha_cbox)
@@ -514,7 +519,7 @@ export default async function (args, obj, data, context) {
                 shear_buttons(fine_shear),
             )
         )
-    ), getter
+    ), getter, setter
 
 
 def get_joint_pointset(static_figure, moving_figure):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -7,7 +7,7 @@ from libertem_ui.applications.image_utils import fine_adjust
 def test_fine_adjust(page: Page):
     circle_image = (np.linalg.norm(np.mgrid[-200: 200, -300: 300], axis=0) < 100)
     circle_image_shifted = np.roll(circle_image, (-50, 80), axis=(0, 1))
-    layout, getter = fine_adjust(circle_image, circle_image_shifted)
+    layout, getter, setter = fine_adjust(circle_image, circle_image_shifted)
     port = np.random.randint(8081, 9957)
     show_th = layout.show(open=False, threaded=True, port=port)
     try:


### PR DESCRIPTION
Possibly should also be added for other utils; let me know if I should do that. Use-case is, for example, applying a known initial transformation in an example notebook, so one can run them from top to bottom.